### PR TITLE
Add collapse support

### DIFF
--- a/syntaxes/kamailio.tmLanguage.json
+++ b/syntaxes/kamailio.tmLanguage.json
@@ -2,6 +2,8 @@
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "kamailio",
 	"firstLineMatch": "\\b(KAMAILIO|kamailio|SER|ser|SIP-ROUTER|sip-router|OPENSER|openser)\\b",
+	"foldingStartMarker": "(?x)/\\*\\*(?!\\*)|^(?![^{]*?//|[^{]*?/\\*(?!.*?\\*/.*?\\{)).*?\\{\\s*($|//|/\\*(?!.*?\\*/.*\\S))",
+    	"foldingStopMarker": "(?<!\\*)\\*\\*/|^\\s*\\}",
 	"patterns": [
 		{
 			"include": "#keywords"


### PR DESCRIPTION
Adds collapse support to the extension for route blocks and any other multi-line areas. First attempt, regex might need some work.