### PR TITLE
Changed Number Sign Comment

### DIFF
--- a/syntaxes/kamailio.tmLanguage.json
+++ b/syntaxes/kamailio.tmLanguage.json
@@ -38,7 +38,7 @@
 		},
 		{
 			"comment": "Line comment",
-			"begin": "\\#[^!]",
+			"begin": "(?<!{s.select,[0-9]|[0-9]|[0-9],)\\#[^!]",
 			"end": "\\n",
 			"name": "comment.line.number-sign.kamailio"
 		},


### PR DESCRIPTION
- Changed the comment.line.number-sign.kamailio
  section to prevent from starting a comment
  when a number sign is used in a s.select
  string transformation.

I did this with a negative lookbehind.